### PR TITLE
Fix calculating absolute position

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,7 +100,7 @@ export default class PrismaZoom extends PureComponent {
 
       // Retrieve rectangle dimensions and mouse position
       const [centerX, centerY] = [rect.width / 2, rect.height / 2]
-      const [relativeX, relativeY] = [x - rect.left, y - rect.top]
+      const [relativeX, relativeY] = [x - rect.left - window.pageXOffset, y - rect.top - window.pageYOffset]
 
       // If we are zooming down, we must try to center to mouse position
       const [absX, absY] = [(centerX - relativeX) / prevZoom, (centerY - relativeY) / prevZoom]


### PR DESCRIPTION
Hi Sylvain,

First, congrats for your react-prismazoom.

I added the PrismaZoom to my webapp and I have an issue when I double click on the image. 

After I scrolled down in my page, the position is wrongly calculated. 
I figured, the calculation of the new position does not take in account the pageYoffset, because the top and left position you get from getBoundingClientRect are related to the viewport and not to the whole page.

Thanks