### PR TITLE
Add prop to enable or disable panning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [2.1.1] - 2021-12-31
+- Add a prop to enable/disable panning
+
 ## [2.1.0] - 2021-12-26
 - Add a prop to lock the component
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ import PrismaZoom from 'react-prismazoom'
 | animDuration | number | 0.25 | Animation duration (in seconds). |
 | doubleTouchMaxDelay | number | 300 | Max delay between two taps to consider a double tap (in milliseconds). |
 | decelerationDuration | number | 750 | Decelerating movement duration after a mouse up or a touch end event (in milliseconds). |
+| pannable | boolean | true | Enable or disable panning in place. |
 | locked | boolean | false | Disable all user's interactions. |
 
 **Note:** all props are optional.

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ export default class PrismaZoom extends PureComponent {
     animDuration: PropTypes.number,
     doubleTouchMaxDelay: PropTypes.number,
     decelerationDuration: PropTypes.number,
+    pannable: PropTypes.bool,
     locked: PropTypes.bool,
   }
 
@@ -38,6 +39,8 @@ export default class PrismaZoom extends PureComponent {
     doubleTouchMaxDelay: 300,
     // Decelerating movement duration after a mouse up or a touch end event (in milliseconds)
     decelerationDuration: 750,
+    // Enable or disable panning in place
+    pannable: true,
     // Disable all user's interactions
     locked: false,
   }
@@ -547,7 +550,7 @@ export default class PrismaZoom extends PureComponent {
    * @return {Object} Object of event listeners
    */
   getEvents() {
-    if (this.props.locked) return {}
+    if (this.props.locked || !this.props.pannable) return {}
 
     if (window.matchMedia('(pointer: fine)').matches) {
       // Apply mouse events only to devices which include an accurate pointing device


### PR DESCRIPTION
Thanks again for adding the `locked` prop recently. I realized I need more flexibility, and would like to be able to lock panning in place while still being able to zoom. 

Originally, I needed the lock feature to free the mouse to perform other clicking functions while zoomed over any point in the image. But the mouse wheel doesn't actually interfere with this, so it would be good to have the option to disable panning only. 

Hope you'll consider!