### PR TITLE
Added support to enable touch event propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,19 +87,20 @@ import PrismaZoom from 'react-prismazoom'
 
 ### Props
 
-| Name | Type | Default | Description |
-| --- | --- | --- |  --- |
-| className | string | None | Class name to apply on the zoom wrapper. |
-| style | object | None | Style to apply on the zoom wrapper. Note that *transform*, *transition*, *cursor*, *touch-action* and *will-change* cannot be overridden. Example: `style={{backgroundColor: 'red'}}`. |
-| minZoom | number | 1 | Minimum zoom ratio. |
-| maxZoom | number | 5 | Maximum zoom ratio. |
-| scrollVelocity | number | 0.1 | Zoom increment or decrement on each scroll wheel detection. |
-| onZoomChange | function | null | Function called each time the zoom value changes. |
-| onPanChange | function | null | Function called each time the posX or posY value changes (aka images was panned). |
-| animDuration | number | 0.25 | Animation duration (in seconds). |
-| doubleTouchMaxDelay | number | 300 | Max delay between two taps to consider a double tap (in milliseconds). |
-| decelerationDuration | number | 750 | Decelerating movement duration after a mouse up or a touch end event (in milliseconds). |
-| locked | boolean | false | Disable all user's interactions. |
+| Name                 | Type | Default | Description                                                                                                                                                                            |
+|----------------------| --- | --- |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| className            | string | None | Class name to apply on the zoom wrapper.                                                                                                                                               |
+| style                | object | None | Style to apply on the zoom wrapper. Note that *transform*, *transition*, *cursor*, *touch-action* and *will-change* cannot be overridden. Example: `style={{backgroundColor: 'red'}}`. |
+| minZoom              | number | 1 | Minimum zoom ratio.                                                                                                                                                                    |
+| maxZoom              | number | 5 | Maximum zoom ratio.                                                                                                                                                                    |
+| scrollVelocity       | number | 0.1 | Zoom increment or decrement on each scroll wheel detection.                                                                                                                            |
+| onZoomChange         | function | null | Function called each time the zoom value changes.                                                                                                                                      |
+| onPanChange          | function | null | Function called each time the posX or posY value changes (aka images was panned).                                                                                                      |
+| animDuration         | number | 0.25 | Animation duration (in seconds).                                                                                                                                                       |
+| doubleTouchMaxDelay  | number | 300 | Max delay between two taps to consider a double tap (in milliseconds).                                                                                                                 |
+| decelerationDuration | number | 750 | Decelerating movement duration after a mouse up or a touch end event (in milliseconds).                                                                                                |
+| locked               | boolean | false | Disable all user's interactions.                                                                                                                                                       |
+| interactive          | boolean | false | Enables touch event propagation.                                                                                                                                                       |
 
 **Note:** all props are optional.
 

--- a/README.md
+++ b/README.md
@@ -87,20 +87,20 @@ import PrismaZoom from 'react-prismazoom'
 
 ### Props
 
-| Name                 | Type | Default | Description                                                                                                                                                                            |
-|----------------------| --- | --- |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| className            | string | None | Class name to apply on the zoom wrapper.                                                                                                                                               |
-| style                | object | None | Style to apply on the zoom wrapper. Note that *transform*, *transition*, *cursor*, *touch-action* and *will-change* cannot be overridden. Example: `style={{backgroundColor: 'red'}}`. |
-| minZoom              | number | 1 | Minimum zoom ratio.                                                                                                                                                                    |
-| maxZoom              | number | 5 | Maximum zoom ratio.                                                                                                                                                                    |
-| scrollVelocity       | number | 0.1 | Zoom increment or decrement on each scroll wheel detection.                                                                                                                            |
-| onZoomChange         | function | null | Function called each time the zoom value changes.                                                                                                                                      |
-| onPanChange          | function | null | Function called each time the posX or posY value changes (aka images was panned).                                                                                                      |
-| animDuration         | number | 0.25 | Animation duration (in seconds).                                                                                                                                                       |
-| doubleTouchMaxDelay  | number | 300 | Max delay between two taps to consider a double tap (in milliseconds).                                                                                                                 |
-| decelerationDuration | number | 750 | Decelerating movement duration after a mouse up or a touch end event (in milliseconds).                                                                                                |
-| locked               | boolean | false | Disable all user's interactions.                                                                                                                                                       |
-| interactive          | boolean | false | Enables touch event propagation.                                                                                                                                                       |
+| Name | Type | Default | Description |
+| --- | --- | --- |  --- |
+| className | string | None | Class name to apply on the zoom wrapper. |
+| style | object | None | Style to apply on the zoom wrapper. Note that *transform*, *transition*, *cursor*, *touch-action* and *will-change* cannot be overridden. Example: `style={{backgroundColor: 'red'}}`. |
+| minZoom | number | 1 | Minimum zoom ratio. |
+| maxZoom | number | 5 | Maximum zoom ratio. |
+| scrollVelocity | number | 0.1 | Zoom increment or decrement on each scroll wheel detection. |
+| onZoomChange | function | null | Function called each time the zoom value changes. |
+| onPanChange | function | null | Function called each time the posX or posY value changes (aka images was panned). |
+| animDuration | number | 0.25 | Animation duration (in seconds). |
+| doubleTouchMaxDelay | number | 300 | Max delay between two taps to consider a double tap (in milliseconds). |
+| decelerationDuration | number | 750 | Decelerating movement duration after a mouse up or a touch end event (in milliseconds). |
+| locked | boolean | false | Disable all user's interactions. |
+| allowTouchEvents | boolean | false | Enables touch event propagation. |
 
 **Note:** all props are optional.
 

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ export default class PrismaZoom extends PureComponent {
     doubleTouchMaxDelay: PropTypes.number,
     decelerationDuration: PropTypes.number,
     locked: PropTypes.bool,
+    interactive: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -40,6 +41,8 @@ export default class PrismaZoom extends PureComponent {
     decelerationDuration: 750,
     // Disable all user's interactions
     locked: false,
+    // By default interactions are not passed
+    interactive: false,
   }
 
   static defaultState = {
@@ -357,7 +360,9 @@ export default class PrismaZoom extends PureComponent {
    * @param  {TouchEvent} event Touch event
    */
   handleTouchStart = (event) => {
-    event.preventDefault()
+    if (!this.props.interactive) {
+      event.preventDefault()
+    }
 
     if (this.lastRequestAnimationId) {
       cancelAnimationFrame(this.lastRequestAnimationId)
@@ -392,7 +397,9 @@ export default class PrismaZoom extends PureComponent {
    * @param  {TouchEvent} event Touch move
    */
   handleTouchMove = (event) => {
-    event.preventDefault()
+    if (!this.props.interactive) {
+      event.preventDefault()
+    }
 
     const { maxZoom, minZoom } = this.props
     let { zoom } = this.state

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ export default class PrismaZoom extends PureComponent {
     doubleTouchMaxDelay: PropTypes.number,
     decelerationDuration: PropTypes.number,
     locked: PropTypes.bool,
-    interactive: PropTypes.bool,
+    allowTouchEvents: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -41,8 +41,8 @@ export default class PrismaZoom extends PureComponent {
     decelerationDuration: 750,
     // Disable all user's interactions
     locked: false,
-    // By default interactions are not passed
-    interactive: false,
+    // By default, all touch events are caught (if set to true touch events propagate)
+    allowTouchEvents: false,
   }
 
   static defaultState = {
@@ -360,7 +360,7 @@ export default class PrismaZoom extends PureComponent {
    * @param  {TouchEvent} event Touch event
    */
   handleTouchStart = (event) => {
-    if (!this.props.interactive) {
+    if (!this.props.allowTouchEvents) {
       event.preventDefault()
     }
 
@@ -397,7 +397,7 @@ export default class PrismaZoom extends PureComponent {
    * @param  {TouchEvent} event Touch move
    */
   handleTouchMove = (event) => {
-    if (!this.props.interactive) {
+    if (!this.props.allowTouchEvents) {
       event.preventDefault()
     }
 


### PR DESCRIPTION
Added a new prop `interactive` that if set to `true` does not stop touch event propagation. This allows interactive elements to still function (like reactstrap tooltips for example).