### PR TITLE
Split locked prop into allowZoom and allowPan

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ import PrismaZoom from 'react-prismazoom'
 | animDuration | number | 0.25 | Animation duration (in seconds). |
 | doubleTouchMaxDelay | number | 300 | Max delay between two taps to consider a double tap (in milliseconds). |
 | decelerationDuration | number | 750 | Decelerating movement duration after a mouse up or a touch end event (in milliseconds). |
-| locked | boolean | false | Disable all user's interactions. |
+| allowZoom | boolean | true | Enable or disable zooming in place.
+| allowPan | boolean | true | Enable or disable panning in place.
 | allowTouchEvents | boolean | false | Enables touch event propagation. |
 
 **Note:** all props are optional.

--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -12,7 +12,8 @@ class App extends Component {
     this.prismaZoom = createRef()
     this.state = {
       zoom: 1,
-      locked: false,
+      allowZoom: true,
+      allowPan: true,
     }
   }
 
@@ -29,9 +30,10 @@ class App extends Component {
   }
 
   onClickOnLock = () => {
-    const { locked } = this.state
+    const { allowZoom, allowPan } = this.state
     this.setState({
-      locked: !locked,
+      allowZoom: !allowZoom,
+      allowPan: !allowPan,
     })
   }
 
@@ -102,7 +104,7 @@ class App extends Component {
           </footer>
         </section>
         <section className="App-wrapper">
-          <PrismaZoom className="App-zoom" locked={this.state.locked} maxZoom={8}>
+          <PrismaZoom className="App-zoom" allowZoom={this.state.allowZoom} allowPan={this.state.allowPan} maxZoom={8}>
             <div className="App-image" style={{ backgroundImage: `url(${backgroundTwo})` }}></div>
             <article className="App-card">
               <header className="App-cardHeader">
@@ -119,7 +121,7 @@ class App extends Component {
             <div className="App-indicator">
               <button className="App-button" onClick={this.onClickOnLock}>
                 <svg className="App-buttonIcon" viewBox="0 0 24 24">
-                  {this.state.locked ? (
+                  {!this.state.allowPan && !this.state.allowZoom ? (
                     <path d="M12 13a1.49 1.49 0 0 0-1 2.61V17a1 1 0 0 0 2 0v-1.39A1.49 1.49 0 0 0 12 13zm5-4V7A5 5 0 0 0 7 7v2a3 3 0 0 0-3 3v7a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3v-7a3 3 0 0 0-3-3zM9 7a3 3 0 0 1 6 0v2H9zm9 12a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1v-7a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1z" />
                   ) : (
                     <path d="M12 13a1.49 1.49 0 0 0-1 2.61V17a1 1 0 0 0 2 0v-1.39A1.49 1.49 0 0 0 12 13zm5-4H9V7a3 3 0 0 1 5.12-2.13 3.08 3.08 0 0 1 .78 1.38 1 1 0 1 0 1.94-.5 5.09 5.09 0 0 0-1.31-2.29A5 5 0 0 0 7 7v2a3 3 0 0 0-3 3v7a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3v-7a3 3 0 0 0-3-3zm1 10a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1v-7a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1z" />

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,8 @@ export default class PrismaZoom extends PureComponent {
     animDuration: PropTypes.number,
     doubleTouchMaxDelay: PropTypes.number,
     decelerationDuration: PropTypes.number,
-    locked: PropTypes.bool,
+    allowZoom: PropTypes.bool,
+    allowPan: PropTypes.bool,
     allowTouchEvents: PropTypes.bool,
   }
 
@@ -39,8 +40,10 @@ export default class PrismaZoom extends PureComponent {
     doubleTouchMaxDelay: 300,
     // Decelerating movement duration after a mouse up or a touch end event (in milliseconds)
     decelerationDuration: 750,
-    // Disable all user's interactions
-    locked: false,
+    // Enable or disable zooming in place
+    allowZoom: true,
+    // Enable or disable panning in place
+    allowPan: true,
     // By default, all touch events are caught (if set to true touch events propagate)
     allowTouchEvents: false,
   }
@@ -260,7 +263,7 @@ export default class PrismaZoom extends PureComponent {
    */
   handleMouseWheel = (event) => {
     event.preventDefault()
-    if (this.props.locked) {
+    if (!this.props.allowZoom) {
       return
     }
 
@@ -291,7 +294,7 @@ export default class PrismaZoom extends PureComponent {
    */
   handleDoubleClick = (event) => {
     event.preventDefault()
-    if (this.props.locked) {
+    if (!this.props.allowZoom) {
       return
     }
 
@@ -308,7 +311,7 @@ export default class PrismaZoom extends PureComponent {
    */
   handleMouseStart = (event) => {
     event.preventDefault()
-    if (this.props.locked) {
+    if (!this.props.allowPan) {
       return
     }
 
@@ -325,7 +328,7 @@ export default class PrismaZoom extends PureComponent {
    */
   handleMouseMove = (event) => {
     event.preventDefault()
-    if (this.props.locked || !this.lastCursor) {
+    if (!this.props.allowPan || !this.lastCursor) {
       return
     }
 
@@ -365,7 +368,7 @@ export default class PrismaZoom extends PureComponent {
       event.preventDefault()
     }
 
-    if (this.props.locked) return
+    if (!this.props.allowPan) return
 
     if (this.lastRequestAnimationId) {
       cancelAnimationFrame(this.lastRequestAnimationId)
@@ -404,7 +407,7 @@ export default class PrismaZoom extends PureComponent {
       event.preventDefault()
     }
 
-    if (this.props.locked || !this.lastTouch) return
+    if (!this.props.allowPan || !this.lastTouch) return
 
     const { maxZoom, minZoom } = this.props
     let { zoom } = this.state


### PR DESCRIPTION
New PR in response to your comments on https://github.com/sylvaindubus/react-prismazoom/pull/31.

This replaces the current `locked` prop with `allowZoom` and `allowPan`, both true by default, to handle zooming and panning events separately. The goal is to allow more flexibility so that zooming can be locked/unlocked independently of panning, and vice versa.

Setting both to `false` will have the same effect as `locked = true`.

Notes:
1. I used `allowPan` instead of `allowMove` since the language seems more consistent with the other props – but let me know if you have a preference.
2. I updated the example so that the effect is the same as before: clicking on the lock will toggle both `allowZoom` and `allowPan` props.