### PR TITLE
Added custom prop to disable mouse wheel

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ import PrismaZoom from 'react-prismazoom'
 | allowPan | boolean | true | Enable or disable panning in place.
 | allowTouchEvents | boolean | false | Enables touch event propagation. |
 | allowParentPanning | boolean | false | When enabled, allows the parent element/page to pan with single-finger touch events as long as zoom = 1. |
+| allowWheel | boolean | true | Enable or disable mouse wheel and touchpad zooming in place |
 
 **Note:** all props are optional.
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,6 +25,7 @@ const PrismaZoom = forwardRef<Ref, Props>((props, forwardedRef) => {
     allowPan = true,
     allowTouchEvents = false,
     allowParentPanning = false,
+    allowWheel = true,
     ...divProps
   } = props
 
@@ -394,7 +395,7 @@ const PrismaZoom = forwardRef<Ref, Props>((props, forwardedRef) => {
    */
   const handleMouseWheel = (event: WheelEvent) => {
     event.preventDefault()
-    if (!allowZoom) return
+    if (!allowZoom || !allowWheel) return
 
     // Use the scroll event delta to determine the zoom velocity
     const velocity = (-event.deltaY * scrollVelocity) / 100

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,10 @@ export type Props = NonNullable<React.PropsWithChildren> &
      * By default, page cannot scroll with touch events
      */
     allowParentPanning?: boolean
+    /**
+     * Enable or disable mouse wheel and touchpad zooming in place
+     */
+    allowWheel?: boolean
   }
 
 export type PositionType = [number, number]


### PR DESCRIPTION
New custom prop is supported. `allowWheel` by default it is `true`. However, if you would like to disable the mouse wheel you can set `allowWheel` as `false`. 

- [x] Readme updated
- [x] Types updated  

Closes #60 