### PR TITLE
Added optional ignoredMouseButtons prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ import PrismaZoom from 'react-prismazoom'
 | allowTouchEvents | boolean | false | Enables touch event propagation. |
 | allowParentPanning | boolean | false | When enabled, allows the parent element/page to pan with single-finger touch events as long as zoom = 1. |
 | allowWheel | boolean | true | Enable or disable mouse wheel and touchpad zooming in place |
+| ignoredMouseButtons | number[] | [] | Optional array of ignored mouse buttons allows to prevent panning for specific mouse buttons. By default all mouse buttons are enabled. [MDN](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button#value) |
 
 **Note:** all props are optional.
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,6 +26,7 @@ const PrismaZoom = forwardRef<Ref, Props>((props, forwardedRef) => {
     allowTouchEvents = false,
     allowParentPanning = false,
     allowWheel = true,
+    ignoredMouseButtons = [],
     ...divProps
   } = props
 
@@ -419,7 +420,7 @@ const PrismaZoom = forwardRef<Ref, Props>((props, forwardedRef) => {
    */
   const handleMouseStart = (event: MouseEvent) => {
     event.preventDefault()
-    if (!allowPan) return
+    if (!allowPan || ignoredMouseButtons.includes(event.button)) return
 
     if (lastRequestAnimationIdRef.current) cancelAnimationFrame(lastRequestAnimationIdRef.current)
     lastCursorRef.current = [event.pageX, event.pageY]

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,11 @@ export type Props = NonNullable<React.PropsWithChildren> &
      * Enable or disable mouse wheel and touchpad zooming in place
      */
     allowWheel?: boolean
+    /**
+     * Optional array of ignored mouse buttons allows to prevent panning for specific mouse buttons. By default all mouse buttons are enabled
+     * https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button#value
+     */
+    ignoredMouseButtons?: number[]
   }
 
 export type PositionType = [number, number]


### PR DESCRIPTION
This update brings in the ability to ignore panning for specific mouse buttons.
The new optional `ignoredMouseButtons` prop allows to avoid collisions while overriding mouse buttons behavior over the component.

My use case is that I need to open a context menu over the `PrismaZoom` component. It doesn't work smooth alongside with panning:
https://user-images.githubusercontent.com/50443966/221240465-cb2a3e19-b4a1-44f5-b8c0-2713196b38fb.mp4

- [ ] Prop type updated
- [ ] README.md updated