### PR TITLE
Fix prevent default action when use wheel and mouse events.

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -384,8 +384,8 @@ const PrismaZoom = forwardRef<Ref, Props>((props, forwardedRef) => {
    * @param  {MouseEvent} event Mouse event
    */
   const handleMouseWheel = (event: WheelEvent) => {
-    event.preventDefault()
     if (!allowZoom || !allowWheel) return
+    event.preventDefault()
 
     // Use the scroll event delta to determine the zoom velocity
     const velocity = (-event.deltaY * scrollVelocity) / 100
@@ -408,8 +408,8 @@ const PrismaZoom = forwardRef<Ref, Props>((props, forwardedRef) => {
    * @param  {MouseEvent} event Mouse event
    */
   const handleMouseStart = (event: MouseEvent) => {
-    event.preventDefault()
     if (!allowPan || ignoredMouseButtons.includes(event.button)) return
+    event.preventDefault()
 
     if (lastRequestAnimationIdRef.current) cancelAnimationFrame(lastRequestAnimationIdRef.current)
     lastCursorRef.current = [event.pageX, event.pageY]
@@ -420,9 +420,8 @@ const PrismaZoom = forwardRef<Ref, Props>((props, forwardedRef) => {
    * @param  {MouseEvent} event Mouse event
    */
   const handleMouseMove = (event: MouseEvent) => {
-    event.preventDefault()
-
     if (!allowPan || !lastCursorRef.current) return
+    event.preventDefault()
 
     const [posX, posY] = [event.pageX, event.pageY]
     const shiftX = posX - lastCursorRef.current[0]


### PR DESCRIPTION
Hi Sylvain,

I added the PrismaZoom to my webapp and I have an issue when I scroll my page. Scrolling the page does not work if the pointer is over an area that can be zoomed in.  This happens because the default action for the wheel is canceled. I propose to override the default action only if the image is scaled.

Thanks