### PR TITLE
Omit preventDefault in handleMouseWheel if allowZoom or allowWheel prop is false

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -384,8 +384,8 @@ const PrismaZoom = forwardRef<Ref, Props>((props, forwardedRef) => {
    * @param  {MouseEvent} event Mouse event
    */
   const handleMouseWheel = useCallback((event: WheelEvent) => {
-    event.preventDefault()
     if (!allowZoom || !allowWheel) return
+    event.preventDefault()
 
     // Use the scroll event delta to determine the zoom velocity
     const velocity = (-event.deltaY * scrollVelocity) / 100


### PR DESCRIPTION
Hey, @sylvaindubus!

I'd like to have the ability to scroll a parent container while the cursor is over PrismaZoom and the `allowWheel={false}`
The objective is to have the capability to enable either zoom or parent container scroll.
In my case, I have a list of images that users can scroll. When the Shift key is held user should be able to zoom the hovered image. Scroll should be enabled after the Shift key is released.

Please take a look and let me know if I missed something.
Thanks in advance!